### PR TITLE
renamed project, updated code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Title: Package for Creating and Analyzing Migration Profiles for Single Cell Tracking / Time Lapse Data
-Package: neutrominer
+Package: migrationminer
 Type: Package
 Version: 0.1.0
 Authors@R: as.person(c( "Tim Becker <tim.becker.83@gmail.com> [aut, cre]"))
 Description: Trajectory data of in vitro cell tracking experiments is difficult
     to analyze in an automated and standardized way. To analyze, visualize and 
-    aggregate these data sets, neutrominer implements different methods to 
+    aggregate these data sets, migrationminer implements different methods to 
     characterize single (cellular) trajectories including speed, directionality, 
     forward migration index or the chemotaxis index. Different methods are 
     provided to assess the tracking quality including 2D / 3D visualizations and 
@@ -31,6 +31,6 @@ Suggests:
     tidyr (>= 0.6.0),
     covr
 VignetteBuilder: knitr
-URL: https://github.com/cells2numbers/neutrominer
-BugReports: https://github.com/cells2numbers/neutrominer/issues
+URL: https://github.com/cells2numbers/migrationminer
+BugReports: https://github.com/cells2numbers/migrationminer/issues
 RoxygenNote: 6.0.1

--- a/R/track.R
+++ b/R/track.R
@@ -12,7 +12,7 @@
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
 #'  data <- dplyr::group_by_(data,"TrackObjects_Label")
-#'  tracks <- neutrominer::track(data,"TrackObjects_Label")
+#'  tracks <- migrationminer::track(data,"TrackObjects_Label")
 #' @export
 track <- function(population, strata) {
   # process `population`, which is the data you get from CellProfiler
@@ -45,7 +45,7 @@ track <- function(population, strata) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
 #' @importFrom magrittr %>%
 #' @importFrom magrittr %<>%
 #' @export
@@ -90,8 +90,8 @@ displace <- function(population, strata) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  speed <- neutrominer::speed(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  speed <- migrationminer::speed(tracks)
 #' @importFrom magrittr %>%
 #' @export
 speed <- function(tracks) {
@@ -117,8 +117,8 @@ speed <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  forward_migration_index <- neutrominer::forward_migration_index(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  forward_migration_index <- migrationminer::forward_migration_index(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @importFrom utils tail
@@ -154,8 +154,8 @@ forward_migration_index <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  lifetime <-  neutrominer::lifetime(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  lifetime <-  migrationminer::lifetime(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @export
@@ -180,8 +180,8 @@ lifetime  <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  angle <-  neutrominer::angle(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  angle <-  migrationminer::angle(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @importFrom utils tail
@@ -206,8 +206,8 @@ angle <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  distance <-  neutrominer::distance(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  distance <-  migrationminer::distance(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @importFrom utils tail
@@ -234,8 +234,8 @@ distance <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  directionality <-  neutrominer::directionality(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  directionality <-  migrationminer::directionality(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @export
@@ -264,8 +264,8 @@ directionality <- function(tracks) {
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
 #'  tau <- 2
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  mean_squared_displacement <-  neutrominer::mean_squared_displacement(tracks,tau)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  mean_squared_displacement <-  migrationminer::mean_squared_displacement(tracks,tau)
 #'
 #' @importFrom magrittr %>%
 #' @export
@@ -287,8 +287,8 @@ mean_squared_displacement <- function(tracks, tau = 10) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  directional_persistence <-  neutrominer::directional_persistence(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  directional_persistence <-  migrationminer::directional_persistence(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @export
@@ -310,8 +310,8 @@ directional_persistence <- function(tracks) {
 #'   Location_Center_Y = c(1, 1, 1, 1, 1),
 #'   TrackObjects_Label = c(rep(1, 5))
 #' )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  chemotaxis_index <-  neutrominer::chemotaxis_index(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  chemotaxis_index <-  migrationminer::chemotaxis_index(tracks)
 #' @importFrom magrittr %>%
 #' @export
 chemotaxis_index <- function(tracks) {
@@ -337,8 +337,8 @@ chemotaxis_index <- function(tracks) {
 #'    Location_Center_Y = c(1, 1, 1, 1, 1),
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
-#'  tracks <- neutrominer::displace(data,"TrackObjects_Label")
-#'  sector_analysis <-  neutrominer::sector_analysis(tracks)
+#'  tracks <- migrationminer::displace(data,"TrackObjects_Label")
+#'  sector_analysis <-  migrationminer::sector_analysis(tracks)
 #'
 #' @importFrom magrittr %>%
 #' @export
@@ -383,9 +383,9 @@ sector_analysis <- function(tracks) {
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
 #'  data <- dplyr::group_by_(data, "TrackObjects_Label")
-#'  tracks <- neutrominer::track(data, "TrackObjects_Label")
+#'  tracks <- migrationminer::track(data, "TrackObjects_Label")
 #'  min_path_length <- 5
-#'  vot <-   neutrominer::valid_observation_time(tracks, min_path_length)
+#'  vot <-   migrationminer::valid_observation_time(tracks, min_path_length)
 #' @importFrom magrittr %>%
 #' @export
 valid_observation_time <- function(tracks, min_path_length = 19) {
@@ -412,9 +412,9 @@ valid_observation_time <- function(tracks, min_path_length = 19) {
 #'    TrackObjects_Label = c(rep(1, 5))
 #'  )
 #'  data <- dplyr::group_by_(data,"TrackObjects_Label")
-#'  tracks <- neutrominer::track(data,"TrackObjects_Label")
+#'  tracks <- migrationminer::track(data,"TrackObjects_Label")
 #'  min_path_length <- 5
-#'  validate_tracks <-   neutrominer::validate_tracks(tracks, min_path_length)
+#'  validate_tracks <-   migrationminer::validate_tracks(tracks, min_path_length)
 #' @importFrom magrittr %>%
 #' @export
 validate_tracks <- function(tracks, min_path_length = 19){
@@ -444,9 +444,9 @@ validate_tracks <- function(tracks, min_path_length = 19){
 #'  )
 #'  strata <- "TrackObjects_Label"
 #'  data <- dplyr::group_by_(data, strata)
-#'  tracks <- neutrominer::track(data, strata)
+#'  tracks <- migrationminer::track(data, strata)
 #'  min_path_length <- 5
-#'  trackQuality <- neutrominer::assess(tracks,min_path_length,strata)
+#'  trackQuality <- migrationminer::assess(tracks,min_path_length,strata)
 #' @importFrom magrittr %>%
 #' @export
 assess <- function(tracks, min_path_length = 19, strata) {

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[![Build Status](https://travis-ci.org/cells2numbers/neutrominer.svg?branch=master)](https://travis-ci.org/cells2numbers/neutrominer) 
-[![Coverage Status](https://img.shields.io/codecov/c/github/cells2numbers/neutrominer/master.svg)](https://codecov.io/github/cells2numbers/neutrominer?branch=master)
+[![Build Status](https://travis-ci.org/cells2numbers/migrationminer.svg?branch=master)](https://travis-ci.org/cells2numbers/migrationminer) 
+[![Coverage Status](https://img.shields.io/codecov/c/github/cells2numbers/migrationminer/master.svg)](https://codecov.io/github/cells2numbers/migrationminer?branch=master)
 
-# neutrominer
-Neutrominer is a R package to analyse and profile in vitro cell tracking and migration data. It is belongs to the [cytominer-verse](https://github.com/cytomining/) used for morphological profiling and allows to create temporal or dynamic profiles. 
+# migrationminer
+migrationminer is a R package to analyse and profile in vitro cell tracking and migration data. It is belongs to the [cytominer-verse](https://github.com/cytomining/) used for morphological profiling and allows to create temporal or dynamic profiles. 
 
 It works well together with CellProiler and the CellProfiler tracking module also parsing other formats is easily possible.
 
 # Installation 
-Neutrominer is not yet available from CRAN but you can install directly from github. First, you need to install the devtools package. You can do this from CRAN. Invoke R and then type
+migrationminer is not yet available from CRAN but you can install directly from github. First, you need to install the devtools package. You can do this from CRAN. Invoke R and then type
 
 ```
 install.packages("devtools")
@@ -18,21 +18,21 @@ Load the package using
 ```
 library(devtools)
 ```
-Now install neutrominer from github using
+Now install migrationminer from github using
 ```
-install_github("cells2numbers/neutrominer")
+install_github("cells2numbers/migrationminer")
 ```
 
 You should see something like 
 ```
-Downloading GitHub repo cells2numbers/neutrominer@master
-from URL https://api.github.com/repos/cells2numbers/neutrominer/zipball/master
-Installing neutrominer
+Downloading GitHub repo cells2numbers/migrationminer@master
+from URL https://api.github.com/repos/cells2numbers/migrationminer/zipball/master
+Installing migrationminer
 '/usr/local/Cellar/r/3.4.1_2/lib/R/bin/R' --no-site-file --no-environ --no-save --no-restore --quiet CMD INSTALL  \
-  '/private/var/folders/qq/v5mwx8g15655gt708s86vys8yzcpll/T/RtmpUyrzzK/devtoolse7f945c7b360/cells2numbers-neutrominer-8a95c5d'  \
+  '/private/var/folders/qq/v5mwx8g15655gt708s86vys8yzcpll/T/RtmpUyrzzK/devtoolse7f945c7b360/cells2numbers-migrationminer-8a95c5d'  \
   --library='/usr/local/lib/R/3.4/site-library' --install-tests 
 
-* installing *source* package ‘neutrominer’ ...
+* installing *source* package ‘migrationminer’ ...
 ** R
 ** tests
 ** preparing package for lazy loading
@@ -40,8 +40,8 @@ Installing neutrominer
 *** installing help indices
 ** building package indices
 ** testing if installed package can be loaded
-* DONE (neutrominer)
-Reloading installed neutrominer
+* DONE (migrationminer)
+Reloading installed migrationminer
 ```
 
 If this does not work for you or you find any bugs, please file an issue! 

--- a/man/angle.Rd
+++ b/man/angle.Rd
@@ -22,7 +22,7 @@ Calculate angle of a track object.
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- angle <-  neutrominer::angle(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ angle <-  migrationminer::angle(tracks)
 
 }

--- a/man/assess.Rd
+++ b/man/assess.Rd
@@ -4,7 +4,7 @@
 \alias{assess}
 \title{Assess track quality.}
 \usage{
-assess(tracks, min_path_length, strata)
+assess(tracks, min_path_length = 19, strata)
 }
 \arguments{
 \item{tracks}{data frame with track objects}
@@ -26,9 +26,9 @@ Assess track quality.
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- strata <- 'TrackObjects_Label'
- data <- dplyr::group_by_(data,strata)
- tracks <- neutrominer::track(data,strata)
+ strata <- "TrackObjects_Label"
+ data <- dplyr::group_by_(data, strata)
+ tracks <- migrationminer::track(data, strata)
  min_path_length <- 5
- trackQuality <- neutrominer::assess(tracks,min_path_length,strata)
+ trackQuality <- migrationminer::assess(tracks,min_path_length,strata)
 }

--- a/man/chemotaxis_index.Rd
+++ b/man/chemotaxis_index.Rd
@@ -22,6 +22,6 @@ data <- tibble::data_frame(
   Location_Center_Y = c(1, 1, 1, 1, 1),
   TrackObjects_Label = c(rep(1, 5))
 )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- chemotaxis_index <-  neutrominer::chemotaxis_index(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ chemotaxis_index <-  migrationminer::chemotaxis_index(tracks)
 }

--- a/man/directional_persistence.Rd
+++ b/man/directional_persistence.Rd
@@ -22,7 +22,7 @@ Calculate the mean directional_persistence of a track object.
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- directional_persistence <-  neutrominer::directional_persistence(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ directional_persistence <-  migrationminer::directional_persistence(tracks)
 
 }

--- a/man/directionality.Rd
+++ b/man/directionality.Rd
@@ -22,7 +22,7 @@ Calculate the directionality of a track object.
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- directionality <-  neutrominer::directionality(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ directionality <-  migrationminer::directionality(tracks)
 
 }

--- a/man/displace.Rd
+++ b/man/displace.Rd
@@ -24,5 +24,5 @@ Add spatial displacement per frame for each track object
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
 }

--- a/man/distance.Rd
+++ b/man/distance.Rd
@@ -22,7 +22,7 @@ Calculate distance traveled and the integrated distance traveled of a track obje
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- distance <-  neutrominer::distance(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ distance <-  migrationminer::distance(tracks)
 
 }

--- a/man/forward_migration_index.Rd
+++ b/man/forward_migration_index.Rd
@@ -22,7 +22,7 @@ Compute the forward migration index of a tracked object
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- forward_migration_index <- neutrominer::forward_migration_index(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ forward_migration_index <- migrationminer::forward_migration_index(tracks)
 
 }

--- a/man/lifetime.Rd
+++ b/man/lifetime.Rd
@@ -22,7 +22,7 @@ Calculate lifetime of a track object.
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- lifetime <-  neutrominer::lifetime(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ lifetime <-  migrationminer::lifetime(tracks)
 
 }

--- a/man/mean_squared_displacement.Rd
+++ b/man/mean_squared_displacement.Rd
@@ -4,7 +4,7 @@
 \alias{mean_squared_displacement}
 \title{Calculate the mean squared displacement of a track object.}
 \usage{
-mean_squared_displacement(tracks, tau)
+mean_squared_displacement(tracks, tau = 10)
 }
 \arguments{
 \item{tracks}{data frame with track objects}
@@ -25,7 +25,7 @@ Calculate the mean squared displacement of a track object.
    TrackObjects_Label = c(rep(1, 5))
  )
  tau <- 2
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- mean_squared_displacement <-  neutrominer::mean_squared_displacement(tracks,tau)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ mean_squared_displacement <-  migrationminer::mean_squared_displacement(tracks,tau)
 
 }

--- a/man/sector_analysis.Rd
+++ b/man/sector_analysis.Rd
@@ -22,7 +22,7 @@ perform sector analysis and label each track according to its direction of movem
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- sector_analysis <-  neutrominer::sector_analysis(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ sector_analysis <-  migrationminer::sector_analysis(tracks)
 
 }

--- a/man/speed.Rd
+++ b/man/speed.Rd
@@ -22,6 +22,6 @@ Add spatial displacement per frame for each track object
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- tracks <- neutrominer::displace(data,'TrackObjects_Label')
- speed <- neutrominer::speed(tracks)
+ tracks <- migrationminer::displace(data,"TrackObjects_Label")
+ speed <- migrationminer::speed(tracks)
 }

--- a/man/track.Rd
+++ b/man/track.Rd
@@ -24,6 +24,6 @@ Compute track statistics
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- data <- dplyr::group_by_(data,'TrackObjects_Label')
- tracks <- neutrominer::track(data,'TrackObjects_Label')
+ data <- dplyr::group_by_(data,"TrackObjects_Label")
+ tracks <- migrationminer::track(data,"TrackObjects_Label")
 }

--- a/man/valid_observation_time.Rd
+++ b/man/valid_observation_time.Rd
@@ -5,7 +5,7 @@
 \title{calculate valid observation time as sum of the length of all
 valid tracks divided by the sum of the length of all tracks}
 \usage{
-valid_observation_time(tracks, min_path_length)
+valid_observation_time(tracks, min_path_length = 19)
 }
 \arguments{
 \item{tracks}{data frame with track objects}
@@ -26,8 +26,8 @@ valid tracks divided by the sum of the length of all tracks
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- data <- dplyr::group_by_(data,'TrackObjects_Label')
- tracks <- neutrominer::track(data,'TrackObjects_Label')
+ data <- dplyr::group_by_(data, "TrackObjects_Label")
+ tracks <- migrationminer::track(data, "TrackObjects_Label")
  min_path_length <- 5
- vot <-   neutrominer::valid_observation_time(tracks, min_path_length)
+ vot <-   migrationminer::valid_observation_time(tracks, min_path_length)
 }

--- a/man/validate_tracks.Rd
+++ b/man/validate_tracks.Rd
@@ -4,7 +4,7 @@
 \alias{validate_tracks}
 \title{Identify valid tracks. Valid tracks are defined as tracks with a life time longer then a predefined value.}
 \usage{
-validate_tracks(tracks, min_path_length)
+validate_tracks(tracks, min_path_length = 19)
 }
 \arguments{
 \item{tracks}{data frame with track objects}
@@ -24,8 +24,8 @@ Identify valid tracks. Valid tracks are defined as tracks with a life time longe
    Location_Center_Y = c(1, 1, 1, 1, 1),
    TrackObjects_Label = c(rep(1, 5))
  )
- data <- dplyr::group_by_(data,'TrackObjects_Label')
- tracks <- neutrominer::track(data,'TrackObjects_Label')
+ data <- dplyr::group_by_(data,"TrackObjects_Label")
+ tracks <- migrationminer::track(data,"TrackObjects_Label")
  min_path_length <- 5
- validate_tracks <-   neutrominer::validate_tracks(tracks, min_path_length)
+ validate_tracks <-   migrationminer::validate_tracks(tracks, min_path_length)
 }

--- a/migrationminer.Rproj
+++ b/migrationminer.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
-library(neutrominer)
+library(migrationminer)
 
-test_check("neutrominer")
+test_check("migrationminer")

--- a/tests/testthat/test-track.R
+++ b/tests/testthat/test-track.R
@@ -23,7 +23,7 @@ test_that("`track` collapse single cell data to track objects", {
     .dots = c("TrackObjects_Label", "Metadata_condition")
     )
 
-  f2 <- neutrominer::track(data2,
+  f2 <- migrationminer::track(data2,
     c("TrackObjects_Label", "Metadata_condition")
     )
 
@@ -136,7 +136,7 @@ test_that("`track` collapse single cell data to track objects", {
     feature_list
     )
 
-  track_data <- neutrominer:::displace(data, strata) %>%
+  track_data <- migrationminer:::displace(data, strata) %>%
     dplyr::group_by_(strata)
 
   expect_equal(
@@ -153,78 +153,78 @@ test_that("`track` collapse single cell data to track objects", {
   )
 
   expect_equal(
-    track_data %>% neutrominer::angle(.),
+    track_data %>% migrationminer::angle(.),
     track_angle
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::chemotaxis_index(.),
+      migrationminer::chemotaxis_index(.),
     track_ci
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::directionality(.),
+      migrationminer::directionality(.),
     track_directionality
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::distance(.),
+      migrationminer::distance(.),
     track_distance
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::directional_persistence(.),
+      migrationminer::directional_persistence(.),
     track_dp
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::forward_migration_index(.),
+      migrationminer::forward_migration_index(.),
     track_fmi
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::lifetime(.),
+      migrationminer::lifetime(.),
     track_life_time
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::mean_squared_displacement(., 2),
+      migrationminer::mean_squared_displacement(., 2),
     track_msd
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::sector_analysis(),
+      migrationminer::sector_analysis(),
     track_sectors
   )
 
   expect_equal(
     track_data %>%
-      neutrominer::speed(),
+      migrationminer::speed(),
     track_speed
   )
 
   expect_equivalent(
     features %>%
-      neutrominer::valid_observation_time(., 3),
+      migrationminer::valid_observation_time(., 3),
     vot
   )
 
   expect_equivalent(
     f2 %>%
-      neutrominer::validate_tracks(., 2),
+      migrationminer::validate_tracks(., 2),
     valid_tracks
   )
 
   expect_equivalent(
-    f2 %>% neutrominer::assess(., 2),
+    f2 %>% migrationminer::assess(., 2),
     track_quality
   )
 


### PR DESCRIPTION
The package neutrominer has been renamed to migrationminor. This reflects the more general purpose of migrationminer (it was initially implemented to analyse migration patterns of neutrophils but can be used to quantify and analyze migration of any tracked cell population).  