### PR TITLE
added colnames for x, y and time coordinates as input to displace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     magrittr (>= 1.5),
     purrr (>= 0.2.2),
     tibble (>= 1.2),
+    plotly (>= 4.7),
 Suggests:
     knitr (>= 1.14),
     readr (>= 1.0.0),

--- a/man/displace.Rd
+++ b/man/displace.Rd
@@ -4,12 +4,19 @@
 \alias{displace}
 \title{Add spatial displacement per frame for each track object}
 \usage{
-displace(population, strata)
+displace(population, strata, x_var = "Location_Center_X",
+  y_var = "Location_Center_Y", t_var = "Metadata_timePoint")
 }
 \arguments{
 \item{population, }{data frame storing single cell data}
 
 \item{strata, }{column name storing the track label}
+
+\item{x_var}{variable name used for x-coordinates}
+
+\item{y_var}{variable name used for y-coordinates}
+
+\item{t_var}{variable name used for time coordinates}
 }
 \value{
 displacement


### PR DESCRIPTION
First function was rewritten with colnames of x, y and time coordinates as input. 

Basically, the old code 
```{r}
  dplyr::mutate(Track_dX = Location_Center_X.x - Location_Center_X.y) %>%
  dplyr::mutate(Track_dY = Location_Center_Y.x - Location_Center_Y.y) %>%
  dplyr::select(-Location_Center_X.x, -Location_Center_Y.x) %>%
  dplyr::rename(Location_Center_X = Location_Center_X.y) %>%
  dplyr::rename(Location_Center_Y = Location_Center_Y.y) %>%
  dplyr::rename(Metadata_timePoint = Metadata_timePoint2) %>%
```

becomes 
```{r}
 dplyr::mutate(
    Track_dX =
      (!!(as.name(stringr::str_c(x_var, ".x")))) -
      (!!(as.name(stringr::str_c(x_var, ".y"))))
  ) %>%
  dplyr::mutate(
    Track_dY =
      (!!(as.name(stringr::str_c(y_var, ".x")))) -
      (!!(as.name(stringr::str_c(y_var, ".y"))))
  ) %>%
  dplyr::select(
    - (!!(as.name(stringr::str_c(x_var, ".x")))),
    - (!!(as.name(stringr::str_c(y_var, ".x"))))
  ) %>%
    #
    # when using rename with expression "=" needs to be replaced with ":=", see
    # https://github.com/tidyverse/dplyr/issues/1600
    # also see vignette("programming")
  dplyr::rename(
    !!x_var := !!stringr::str_c(x_var, ".y")
  ) %>%
  dplyr::rename(
    !!y_var := !!stringr::str_c(y_var, ".y")
  ) %>%

```

ToDo: look for a better solution to calculate the displacement. Better = without the need of the helper column! 


Helpful sources:      https://github.com/tidyverse/dplyr/issues/1600,  also see vignette("programming")